### PR TITLE
Now extracts vold from the phone

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -167,6 +167,7 @@ COMMON_BINS="
 	proximity.init
 	qmiproxy
 	qmuxd
+	vold
 	"
 copy_files "$COMMON_BINS" "system/bin" ""
 


### PR DESCRIPTION
Now extracts vold from the phone, since the one we build in the tree is for ICS, which doesn't work with GB based kernels
