### PR TITLE
Extract OMX hardware decoders

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -143,6 +143,7 @@ COMMON_LIBS="
 	libauth.so
 	libcm.so
 	libdiag.so
+	libdivxdrmdecrypt.so
 	libdsi_netctrl.so
 	libdsm.so
 	libdss.so
@@ -151,8 +152,13 @@ COMMON_LIBS="
 	libgstk_exp.so
 	libidl.so
 	libmmgsdilib.so
+	libmm-adspsvc.so
 	libnetmgr.so
 	libnv.so
+	libOmxAacDec.so
+	libOmxH264Dec.so
+	libOmxMp3Dec.so
+	libOmxVp8Dec.so
 	liboncrpc.so
 	libpbmlib.so
 	libqdp.so


### PR DESCRIPTION
This is a fix for issue 4, and Mozilla [Bug 766395](https://bugzilla.mozilla.org/show_bug.cgi?id=766395). It adds the libOmx hardware decoders to the list of files to be extracted from the device.
