### PR TITLE
Adjust ro.moz.cam.0.sensor_offset

### DIFF
--- a/full_otoro.mk
+++ b/full_otoro.mk
@@ -13,7 +13,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
   rild.libpath=/system/lib/libril-qc-1.so \
   rild.libargs=-d/dev/smd0 \
   ro.use_data_netmgrd=true \
-  ro.moz.cam.0.sensor_offset=270 \
+  ro.moz.cam.0.sensor_offset=180 \
   ro.moz.ril.simstate_extra_field=true \
   ro.moz.ril.emergency_by_default=true
 


### PR DESCRIPTION
Adjust ro.moz.cam.0.sensor_offset so that we can remove the 270-degree fudge factor from camera.js.
