### PR TITLE
Bug 814797 - Remove ATFWD-daemon since it doesn't seem to be working

### DIFF
--- a/extract-files.sh
+++ b/extract-files.sh
@@ -212,7 +212,6 @@ fi
 copy_files "$COMMON_LIBS" "system/lib" ""
 
 COMMON_BINS="
-	ATFWD-daemon
 	akmd8962
 	bridgemgrd
 	fm_qsoc_patches


### PR DESCRIPTION
I noticed (as mentioned in bug 814797) that there is a new ATFWD-daemon being launched every 5 seconds. This removes it, since I don't think we're using it anyways.
