### PR TITLE
Bug 823845 - [Bluetooth]SDP record of A2DP shall be removed, it might leads bluetooth certification fail

### DIFF
--- a/audio.conf
+++ b/audio.conf
@@ -1,0 +1,53 @@
+# Configuration file for the audio service
+
+# This section contains options which are not specific to any
+# particular interface
+# NOTE: Enable=Sink means that bluetoothd exposes Sink interface for remote
+# devices, and the local device is a Source
+[General]
+Disable=Headset,Gateway,Source,Sink,Control
+
+# request master role for incoming connections
+# so as to reduce the number of piconets and
+# allow lot more incoming connections
+Master=true
+
+# If we want to disable support for specific services
+# Defaults to supporting all implemented services
+#Disable=Control,Source
+
+# SCO routing. Either PCM or HCI (in which case audio is routed to/from ALSA)
+# Defaults to HCI
+#SCORouting=PCM
+
+# Automatically connect both A2DP and HFP/HSP profiles for incoming
+# connections. Some headsets that support both profiles will only connect the
+# other one automatically so the default setting of true is usually a good
+# idea.
+#AutoConnect=true
+
+# Headset interface specific options (i.e. options which affect how the audio
+# service interacts with remote headset devices)
+#[Headset]
+
+# Set to true to support HFP (in addition to HSP only which is the default)
+# Defaults to false
+#HFP=true
+
+# Maximum number of connected HSP/HFP devices per adapter. Defaults to 1
+#MaxConnections=1
+
+# Set to true to enable use of fast connectable mode (faster page scanning)
+# for HFP when incomming call starts. Default settings are restored after
+# call is answered or rejected. Page scan interval is much shorter and page
+# scan type changed to interlaced. Such allows faster connection initiated
+# by a headset.
+FastConnectable=false
+
+# Just an example of potential config options for the other interfaces
+[A2DP]
+SBCSources=1
+MPEG12Sources=0
+
+[AVRCP]
+InputDeviceName=AVRCP

--- a/full_otoro.mk
+++ b/full_otoro.mk
@@ -3,7 +3,8 @@ PRODUCT_COPY_FILES := \
   device/qcom/otoro/Fts-touchscreen.idc:system/usr/idc/Fts-touchscreen.idc \
   device/qcom/otoro/atmel-touchscreen.idc:system/usr/idc/atmel-touchscreen.idc \
   device/qcom/otoro/media_profiles.xml:system/etc/media_profiles.xml \
-  device/qcom/msm7627a/wpa_supplicant.conf:system/etc/wifi/wpa_supplicant.conf
+  device/qcom/msm7627a/wpa_supplicant.conf:system/etc/wifi/wpa_supplicant.conf \
+  device/qcom/otoro/audio.conf:system/etc/bluetooth/audio.conf
 
 $(call inherit-product-if-exists, vendor/qcom/otoro/otoro-vendor-blobs.mk)
 $(call inherit-product-if-exists, vendor/qcom/common/vendor-blobs.mk)


### PR DESCRIPTION
Bug 823845 - [Bluetooth]SDP record of A2DP shall be removed, it might leads bluetooth certification fail. Disable A2DP/AVRCP in BlueZ stack for bluetooth certification
